### PR TITLE
Umer/partition blocker fix

### DIFF
--- a/lib/libc/include/string.h
+++ b/lib/libc/include/string.h
@@ -37,6 +37,7 @@ void *memset (void *, int, size_t);
 char       *strcat(char *, char const *);
 char       *strchr(char const *, int) __PURE;
 int         strcmp(char const *, char const *) __PURE;
+int         stricmp(char const *, char const *) __PURE;
 char       *strcpy(char *, char const *);
 char const *strerror(int) __CONST;
 size_t      strlen(char const *) __PURE;

--- a/lib/libc/string/rules.mk
+++ b/lib/libc/string/rules.mk
@@ -15,6 +15,7 @@ C_STRING_OPS := \
 	strcpy \
 	strdup \
 	strerror \
+	stricmp \
 	strlcat \
 	strlcpy \
 	strlen \

--- a/lib/libc/string/stricmp.c
+++ b/lib/libc/string/stricmp.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (c) 2024, Umer Uddin <umer.uddin@mentallysanemainliners.org>
+ */
+
+#include <string.h>
+#include <ctype.h>
+
+int stricmp(const char *s1, const char *s2) {
+    unsigned char c1 = '\0';
+    unsigned char c2 = '\0';
+
+    do {
+        c1 = *s1++;
+        c2 = *s2++;
+        c1 = tolower(c1);
+        c2 = tolower(c2);
+        if (c1 != c2) {
+            return (int)c1 - (int)c2;
+        }
+    } while (c1 != '\0');
+
+    return 0;
+}


### PR DESCRIPTION
We now detect blocked partitions without case sensitivity, making the bootloader even more safe, we also now block said partitions from being erased too.

Also we implement stricmp (I don't know why it wasn't implemented before)