### PR TITLE
Change default cross compiler

### DIFF
--- a/arch/arm64/toolchain.mk
+++ b/arch/arm64/toolchain.mk
@@ -3,13 +3,13 @@ ARCH_arm64_TOOLCHAIN_INCLUDED := 1
 
 ifndef ARCH_arm64_TOOLCHAIN_PREFIX
 	ifeq ($(TOOLCHAIN_PREFIX),)
-		ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-elf-
+		ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-linux-gnu-
 		FOUNDTOOL=$(shell which $(ARCH_arm64_TOOLCHAIN_PREFIX)gcc)
 		ifeq ($(FOUNDTOOL),)
-			ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-elf-
+			ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-linux-gnu-
 			FOUNDTOOL=$(shell which $(ARCH_arm64_TOOLCHAIN_PREFIX)gcc)
 			ifeq ($(FOUNDTOOL),)
-				ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-elf-
+				ARCH_arm64_TOOLCHAIN_PREFIX := aarch64-linux-gnu-
 				FOUNDTOOL=$(shell which $(ARCH_arm64_TOOLCHAIN_PREFIX)gcc)
 				ifeq ($(FOUNDTOOL),)
 					$(error cannot find toolchain, please set ARCH_arm64_TOOLCHAIN_PREFIX or add it to your path)

--- a/build.config.c1s
+++ b/build.config.c1s
@@ -1,5 +1,5 @@
 DEFCONFIG=c1s
-GCC_VERSION=aarch64-elf-5.3.0-Linux-x86_64
+GCC_VERSION=aarch64-linux-gnu-14.2.0-Linux-x86_64
 FILES="
 build-c1s/lk.bin:bootloader.img
 "

--- a/build.config.universal9830
+++ b/build.config.universal9830
@@ -1,5 +1,5 @@
 DEFCONFIG=universal9830_bringup
-GCC_VERSION=aarch64-elf-5.3.0-Linux-x86_64
+GCC_VERSION=aarch64-linux-gnu-14.2.0-Linux-x86_64
 FILES="
 build-universal9830_bringup/lk.bin:bootloader.img
 "

--- a/build.config.x1s
+++ b/build.config.x1s
@@ -1,5 +1,5 @@
 DEFCONFIG=x1s
-GCC_VERSION=aarch64-elf-5.3.0-Linux-x86_64
+GCC_VERSION=aarch64-linux-gnu-14.2.0-Linux-x86_64
 FILES="
 build-x1s/lk.bin:bootloader.img
 "


### PR DESCRIPTION
The compiler currently used (aarch64-elf version 5.3) doesn't support PIC and makes devices freeze on the Samsung logo when attempting to boot the compiled binaries.