### PR TITLE
Fix fastboot UI scaling

### DIFF
--- a/lib/lk3rd/include/lk3rd/display.h
+++ b/lib/lk3rd/include/lk3rd/display.h
@@ -6,7 +6,7 @@
 #include "fastboot_menu.h"
 
 #define FONT_X 16
-#define MAX_NUM_CHAR_PER_LINE (LCD_WIDTH / (FONT_X + 7))
+#define MAX_NUM_CHAR_PER_LINE ((LCD_WIDTH / FONT_X) - 6)
 
 void draw_menu(enum action current_action);
 


### PR DESCRIPTION
I don't know why this original solution worked on c1s, but on x1s and z3s (devices with 1440p screens as opposed to 1080p screens) this caused loads of havoc in scaling.