### PR TITLE
Project: re-enable -Werror

### DIFF
--- a/engine.mk
+++ b/engine.mk
@@ -65,7 +65,7 @@ GLOBAL_COMPILEFLAGS += -fno-builtin
 GLOBAL_COMPILEFLAGS += -fno-delete-null-pointer-checks
 GLOBAL_COMPILEFLAGS += -D__UFS_CAL_LK__
 GLOBAL_CFLAGS := --std=gnu11 -fPIC -Werror-implicit-function-declaration -Wstrict-prototypes -Wwrite-strings
-# GLOBAL_CFLAGS += -Werror
+GLOBAL_CFLAGS += -Werror
 GLOBAL_CPPFLAGS := --std=c++11 -fno-exceptions -fno-rtti -fno-threadsafe-statics
 #GLOBAL_CPPFLAGS += -Weffc++
 GLOBAL_ASMFLAGS := -DASSEMBLY


### PR DESCRIPTION
It's good practice and we fixed all of the warnings in the bootloader anyways, we shouldn't introduce new ones.