### PR TITLE
lib: fdtapi: Check custom0/custom1 that was made with big endian configurations

### DIFF
--- a/lib/fdtapi/fdtapi.c
+++ b/lib/fdtapi/fdtapi.c
@@ -59,7 +59,8 @@ int merge_dto_to_main_dtb(unsigned int board_id, unsigned int board_rev)
 		u32 id = fdt32_to_cpu(dt_entry->id);
 		u32 rev = fdt32_to_cpu(dt_entry->rev);
 
-		if(fdt32_to_cpu(dt_entry->custom[0]) <= board_rev && fdt32_to_cpu(dt_entry->custom[1]) >= board_rev) {
+		if((fdt32_to_cpu(dt_entry->custom[0]) <= board_rev && fdt32_to_cpu(dt_entry->custom[1]) >= board_rev) ||
+		   (dt_entry->custom[0] <= board_rev && dt_entry->custom[1] >= board_rev)) {
 			dtbo_idx = i;
 			printf("DTBO: id: 0x%x, rev: 0x%x, dtbo_idx: %d\n", id, rev, dtbo_idx);
 			//print_lcd_update(FONT_YELLOW, FONT_BLACK,


### PR DESCRIPTION
Alot of custom kernels have dtbo configurations that have a Big Endian configuration, where-as stock has a Little Endian configuration, without this change, the right DTBO can not be found, so merging will not work, nor booting Android.