### PR TITLE
dev/usb/device: gadget: switch to generic Google USB properties

### DIFF
--- a/dev/usb/device/gadget.c
+++ b/dev/usb/device/gadget.c
@@ -44,9 +44,6 @@ struct _udev_gadget {
 	struct list_node string_desc_list_head;
 	int sting_cnt;
 
-	unsigned short platform_vid;
-	unsigned short platform_pid;
-	unsigned short platform_bcd_dev_verion;
 	unsigned char vendor_str_num;
 	unsigned char product_str_num;
 	unsigned char serial_str_num;
@@ -305,9 +302,9 @@ int make_dev_desc(USB_SPEED speed, USB_DEVICE_DESCRIPTOR *dev_desc)
 		dev_desc->bcdUSB = 0x0210;	// Ver 2.10
 		dev_desc->bMaxPacketSize0 = 64;
 	}
-	dev_desc->idVendor = udev_gadget.platform_vid;
-	dev_desc->idProduct = udev_gadget.platform_pid;
-	dev_desc->bcdDevice = udev_gadget.platform_bcd_dev_verion;
+	dev_desc->idVendor = USB_DEVICE_VENDOR_ID;
+	dev_desc->idProduct = USB_DEVICE_PRODUCT_ID;
+	dev_desc->bcdDevice = USB_DEVICE_REVISION_ID;
 
 	dev_desc->iManufacturer = udev_gadget.vendor_str_num;
 	dev_desc->iProduct = udev_gadget.product_str_num;
@@ -598,8 +595,6 @@ static void gadget_init(uint level)
 		list_initialize(&udev_gadget.dev_infor_list_head);
 	if (udev_gadget.string_desc_list_head.next == NULL)
 		list_initialize(&udev_gadget.string_desc_list_head);
-	/* Get VID, PID and Device Version from platform or target */
-	gadget_probe_pid_vid_version(&udev_gadget.platform_vid, &udev_gadget.platform_pid, &udev_gadget.platform_bcd_dev_verion);
 	/* Get Vendor(Manufacture) String */
 	udev_gadget.vendor_str_num = gadget_get_vendor_string();
 	/* Get Product String */

--- a/include/dev/usb/gadget.h
+++ b/include/dev/usb/gadget.h
@@ -22,6 +22,12 @@
 #define	USB_STDREQ_NOT_MINE 1
 #define	USB_STDREQ_ERROR -1
 
+/* Generic fastboot bootloader interface properties */
+/* From android_winusb.inf */
+#define USB_DEVICE_VENDOR_ID 0x18D1
+#define USB_DEVICE_PRODUCT_ID 0x4D00
+#define USB_DEVICE_REVISION_ID 0x0000
+
 enum gadget_buf_opt {
 	GADGET_BUF_NO_OPTION = 0,
 

--- a/platform/exynos3830/usb/usb.c
+++ b/platform/exynos3830/usb/usb.c
@@ -35,13 +35,6 @@
 
 static unsigned int dwc3_isr_num = (USB_INT_NUM + 32);
 
-void gadget_probe_pid_vid_version(unsigned short *vid, unsigned short *pid, unsigned short *bcd_version)
-{
-	*vid = 0x18D1;
-	*pid = 0x0002;
-	*bcd_version = 0x0100;
-}
-
 static const char vendor_str[] = "Samsung Semiconductor, S.LSI Division";
 static const char product_str[] = "Exynos3830 LK Bootloader";
 static char serial_id[16] = "No Serial";

--- a/platform/exynos9630/usb/usb.c
+++ b/platform/exynos9630/usb/usb.c
@@ -39,13 +39,6 @@
 
 static unsigned int dwc3_isr_num = (USB_INT_NUM + 32);
 
-void gadget_probe_pid_vid_version(unsigned short *vid, unsigned short *pid, unsigned short *bcd_version)
-{
-	*vid = 0x18D1;
-	*pid = 0x0002;
-	*bcd_version = 0x0100;
-}
-
 static const char vendor_str[] = "Samsung Exynos probably :)";
 static const char product_str[] = "lk3rd [Exynos 990]";
 static char serial_id[16] = "No Serial";

--- a/platform/exynos9830/usb/usb.c
+++ b/platform/exynos9830/usb/usb.c
@@ -43,13 +43,6 @@
 
 static unsigned int dwc3_isr_num = (USB_INT_NUM + 32);
 
-void gadget_probe_pid_vid_version(unsigned short *vid, unsigned short *pid, unsigned short *bcd_version)
-{
-	*vid = 0x18D1;
-	*pid = 0x0002;
-	*bcd_version = 0x0100;
-}
-
 static const char vendor_str[] = "Samsung - " PLATFORM;
 static const char product_str[] = TARGET " - lk3rd";
 static char serial_id[16] = "No Serial";


### PR DESCRIPTION
With the default hardcoded Product ID for the Google Android Fastboot Interface, the Windows driver will not properly recognize the device running lk3rd until the driver is installed forcefully through Device Manager, which results in a not-so-pleasant UX for end users. This PR hardcodes the VID, PID and RID to the Generic Fastboot Interface from Google, which will result in the driver installing automatically, provided that the Windows Driver Store contains the INF file (Right click on android_winusb.inf -> Install). This PR also commonizes the device properties between platforms, as there is no objective reason for it to be different to the generic one.