### PR TITLE
Mainline quirks

### DIFF
--- a/app/exynos_boot/boot/cmd_scatter_load_boot.c
+++ b/app/exynos_boot/boot/cmd_scatter_load_boot.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <platform/bootimg.h>
 #include <lib/console.h>
+#include <libfdt.h>
 
 int cmd_scatter_load_boot(int argc, const cmd_args *argv)
 {
@@ -59,7 +60,8 @@ int cmd_scatter_load_boot(int argc, const cmd_args *argv)
 	dtb_offset = second_stage_offset;
 #endif
 
-	dtb_offset = dtb_offset + 0x40;
+	if(fdt_check_header((const void *)(boot_addr + dtb_offset)))
+		dtb_offset = dtb_offset + 0x40;
 
 	if (kernel_addr)
 		memcpy((void *)kernel_addr, (const void *)(boot_addr + kernel_offset), (size_t)b_hdr->kernel_size);

--- a/app/exynos_boot/boot/mainline_boot.c
+++ b/app/exynos_boot/boot/mainline_boot.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
+#include <platform/exynos9830.h>
+#include <lib/console.h>
+#include <platform/bootimg.h>
+#include <pit.h>
+#include <string.h>
+#include <arch/arch_ops.h>
+#include <platform/smc.h>
+#include <libfdt.h>
+#include <dev/usb/gadget.h>
+
+/* Hacky. */
+void arm_generic_timer_disable(void);
+int cmd_scatter_load_boot(int argc, const cmd_args *argv);
+
+void mainline_boot(void)
+{
+	int ret;
+	struct pit_entry *ptn;
+	cmd_args argv[6];
+	boot_img_hdr *boot_image = (boot_img_hdr *)BOOT_BASE;
+
+	ptn = pit_get_part_info("boot");
+	if (ptn == 0) {
+		printf("Partition 'boot' does not exist\n");
+		return;
+	} else {
+		pit_access(ptn, PIT_OP_LOAD, (u64)BOOT_BASE, 0);
+	}
+
+	if(strncmp((char*)boot_image->magic, BOOT_MAGIC, 8))
+	{
+		start_usb_gadget();
+		while(1){}
+	}
+
+	argv[1].u = BOOT_BASE;
+	argv[2].u = KERNEL_BASE;
+	argv[3].u = RAMDISK_BASE;
+	argv[4].u = DT_BASE;
+	argv[5].u = 0;
+	cmd_scatter_load_boot(6, argv);
+
+	ret = fdt_check_header((void*)DT_BASE);
+	if (ret) {
+		printf("libfdt fdt_check_header(): %s\n", fdt_strerror(ret));
+		return;
+	}
+
+	/* notify EL3 Monitor end of bootloader */
+	exynos_smc(SMC_CMD_END_OF_BOOTLOADER, 0, 0, 0);
+
+	/* before jumping to kernel. disable interrupts */
+	arch_disable_ints();
+
+	/* before jumping to kernel. disble arch_timer */
+	arm_generic_timer_disable();
+
+	void (*kernel_entry)(int r0, int r1, int r2, int r3);
+	kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE;
+	kernel_entry(DT_BASE, 0, 0, 0);
+
+	/* We shouldn't get here. */
+	return;
+}

--- a/app/exynos_boot/exynos_boot.c
+++ b/app/exynos_boot/exynos_boot.c
@@ -23,8 +23,10 @@
 #include <dev/boot.h>
 #include <dev/debug/dss.h>
 #include <dev/debug/dss_store_ramdump.h>
+#include <lk3rd/mainline_quirks.h>
 
 int cmd_boot(int argc, const cmd_args *argv);
+void mainline_boot(void);
 
 static unsigned int need_do_fastboot = 0;
 static const char *fastboot_reason[] = {
@@ -70,7 +72,12 @@ static void exynos_boot_task(const struct app_descriptor *app, void *args)
 	if (!val)
 		start_usb_gadget();
 	else
-		cmd_boot(0, 0);
+	{
+		if (lk3rd_get_mainline_quirks() == 0)
+			cmd_boot(0, 0);
+		else
+			mainline_boot();
+	}
 
 	return;
 }

--- a/app/exynos_boot/rules.mk
+++ b/app/exynos_boot/rules.mk
@@ -5,6 +5,7 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/exynos_boot.c \
 	$(LOCAL_DIR)/boot/cmd_boot.c \
 	$(LOCAL_DIR)/boot/cmd_display.c \
-	$(LOCAL_DIR)/boot/cmd_scatter_load_boot.c
+	$(LOCAL_DIR)/boot/cmd_scatter_load_boot.c \
+	$(LOCAL_DIR)/boot/mainline_boot.c
 
 include make/module.mk

--- a/lib/lk3rd/display.c
+++ b/lib/lk3rd/display.c
@@ -13,6 +13,7 @@
 
 #include "include/lk3rd/display.h"
 #include "include/lk3rd/fastboot_menu.h"
+#include "include/lk3rd/mainline_quirks.h"
 
 void draw_line_lcd(int color_fg, int color_bg)
 {
@@ -67,6 +68,8 @@ void draw_current_action(enum action current_action)
 	}
 }
 
+
+
 void draw_menu(enum action current_action)
 {
 	clear_screen(FONT_BLACK);
@@ -86,4 +89,10 @@ void draw_menu(enum action current_action)
 	print_lcd_update(FONT_WHITE, FONT_BLACK, "PRODUCT_NAME - %s", version.platform);
 	print_lcd_update(FONT_WHITE, FONT_BLACK, "BOOTLOADER VERSION - DEV (%s)", version.buildid);
 	print_lcd_update(FONT_RED,   FONT_BLACK, "DEVICE STATE - unlocked");
+
+	if(lk3rd_get_mainline_quirks() == 1)
+		print_lcd_update(FONT_YELLOW, FONT_BLACK, "MAINLINE QUIRKS - enabled");
+	else
+		print_lcd_update(FONT_GREEN, FONT_BLACK, "MAINLINE QUIRKS - disabled");
+
 }

--- a/lib/lk3rd/include/lk3rd/fastboot_menu.h
+++ b/lib/lk3rd/include/lk3rd/fastboot_menu.h
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2024 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
 #ifndef FASTBOOT_MENU
 #define FASTBOOT_MENU
 
@@ -12,5 +21,6 @@ enum action {
 };
 
 int fastboot_menu_entry(void*);
+void notify_action_switch(int modifier);
 
 #endif /* FASTBOOT_MENU */

--- a/lib/lk3rd/include/lk3rd/keys.h
+++ b/lib/lk3rd/include/lk3rd/keys.h
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2024 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
 #ifndef KEYS_H
 #define KEYS_H
 

--- a/lib/lk3rd/include/lk3rd/mainline_quirks.h
+++ b/lib/lk3rd/include/lk3rd/mainline_quirks.h
@@ -7,16 +7,10 @@
  *
  */
 
-#ifndef DISPLAY
-#define DISPLAY
+#ifndef MAINLINE_QUIRKS_H
+#define MAINLINE_QUIRKS_H
 
-#include <lib/font_display.h>
+int lk3rd_switch_mainline_quirks(bool enable);
+int lk3rd_get_mainline_quirks(void);
 
-#include "fastboot_menu.h"
-
-#define FONT_X 16
-#define MAX_NUM_CHAR_PER_LINE ((LCD_WIDTH / FONT_X) - 6)
-
-void draw_menu(enum action current_action);
-
-#endif /* DISPLAY */
+#endif

--- a/lib/lk3rd/include/lk3rd/persistent_storage.h
+++ b/lib/lk3rd/include/lk3rd/persistent_storage.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
+#ifndef LK3RD_PERSISTENTSTORAGE_H
+#define LK3RD_PERSISTENTSTORAGE_H
+
+int persistent_storage_read(int entry);
+int persistent_storage_write(int entry, int value);
+
+enum persistent_storage_entries {
+        LK3RD_MAINLINE_QUIRKS = 0x0,
+};
+
+#endif // LK3RD_PERSISTENTSTORAGE_H

--- a/lib/lk3rd/mainline_quirks.c
+++ b/lib/lk3rd/mainline_quirks.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <lk3rd/persistent_storage.h>
+#include <lk3rd/mainline_quirks.h>
+
+int lk3rd_switch_mainline_quirks(bool enable)
+{
+	int ret;
+
+	persistent_storage_write(LK3RD_MAINLINE_QUIRKS, enable);
+
+	ret = persistent_storage_read(LK3RD_MAINLINE_QUIRKS);
+
+	if(ret != enable)
+	{
+		printf("lk3rd: couldn't write to persistent storage, e: %i g: %i\n",
+		       enable, ret);
+	}
+
+	return ret;
+}
+
+int lk3rd_get_mainline_quirks()
+{
+	return persistent_storage_read(LK3RD_MAINLINE_QUIRKS);
+}

--- a/lib/lk3rd/persistent_storage.c
+++ b/lib/lk3rd/persistent_storage.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Igor Belwon <igor.belwon@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
+#include <part.h>
+#include <lk3rd/persistent_storage.h>
+
+#define PERSISTENT_STORAGE_OFFSET 0x175000
+#define PERSISTENT_STORAGE_SIZE 0x2000
+#define PERSISTENT_STORAGE_ENTRIES sizeof(persistent_storage_entries)
+#define TEMP_BUFFER_OFFSET 0x94000000
+
+int persistent_storage_read(int entry)
+{
+	void *part;
+	int *buffer = (int *)TEMP_BUFFER_OFFSET;
+
+	part = part_get("lk3rd");
+
+	part_read_partial(part, (void*)TEMP_BUFFER_OFFSET,
+				PERSISTENT_STORAGE_OFFSET,
+				PERSISTENT_STORAGE_SIZE);
+
+	return buffer[entry];
+}
+
+int persistent_storage_write(int entry, int value)
+{
+	void *part;
+	int *buffer = (int *)TEMP_BUFFER_OFFSET;
+
+	part = part_get("lk3rd");
+
+	part_read_partial(part, (void*)TEMP_BUFFER_OFFSET,
+				PERSISTENT_STORAGE_OFFSET,
+				PERSISTENT_STORAGE_SIZE);
+
+	buffer[entry] = value;
+
+	part_write_partial(part, (void*)TEMP_BUFFER_OFFSET,
+				 PERSISTENT_STORAGE_OFFSET,
+				 PERSISTENT_STORAGE_SIZE);
+
+	printf("Wrote %i to %x\n", value, *buffer);
+
+	return 0;
+}

--- a/lib/lk3rd/rules.mk
+++ b/lib/lk3rd/rules.mk
@@ -6,6 +6,7 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/display.c \
 	$(LOCAL_DIR)/fastboot_menu.c \
 	$(LOCAL_DIR)/keys.c \
-
+	$(LOCAL_DIR)/mainline_quirks.c \
+	$(LOCAL_DIR)/persistent_storage.c \
 
 include make/module.mk


### PR DESCRIPTION
This adds some useful quality of life changes when booting mainline kernel.

To enable:
```
fastboot oem enable-mainline-quirks
```

To disable:
```
fastboot oem disable-mainline-quirks
```