### PR TITLE
exynos9830: Skip MMC Initialisation for mobile phones

### DIFF
--- a/target/c2s/include/target/board_info.h
+++ b/target/c2s/include/target/board_info.h
@@ -18,6 +18,8 @@
 #define CONFIG_SUB_PMIC_S2DOS05
 #define CONFIG_UFS_BOARD_TYPE	1      /* smdk : 0, universal : 1 */
 
+#define CONFIG_SKIP_MMC_INIT
+
 #define CONFIG_USE_RPMB
 #define CONFIG_USE_F2FS
 #define RPMB_BLOCK_PER_PARTITION      512

--- a/target/r8s/include/target/board_info.h
+++ b/target/r8s/include/target/board_info.h
@@ -18,6 +18,8 @@
 #define CONFIG_SUB_PMIC_S2DOS05
 #define CONFIG_UFS_BOARD_TYPE	1      /* smdk : 0, universal : 1 */
 
+#define CONFIG_SKIP_MMC_INIT
+
 #define CONFIG_USE_RPMB
 #define CONFIG_USE_F2FS
 #define RPMB_BLOCK_PER_PARTITION      512

--- a/target/x1s/include/target/board_info.h
+++ b/target/x1s/include/target/board_info.h
@@ -18,6 +18,8 @@
 #define CONFIG_SUB_PMIC_S2DOS05
 #define CONFIG_UFS_BOARD_TYPE	1      /* smdk : 0, universal : 1 */
 
+#define CONFIG_SKIP_MMC_INIT
+
 #define CONFIG_USE_RPMB
 #define CONFIG_USE_F2FS
 #define RPMB_BLOCK_PER_PARTITION      512

--- a/target/y2s/include/target/board_info.h
+++ b/target/y2s/include/target/board_info.h
@@ -18,6 +18,8 @@
 #define CONFIG_SUB_PMIC_S2DOS05
 #define CONFIG_UFS_BOARD_TYPE	1      /* smdk : 0, universal : 1 */
 
+#define CONFIG_SKIP_MMC_INIT
+
 #define CONFIG_USE_RPMB
 #define CONFIG_USE_F2FS
 #define RPMB_BLOCK_PER_PARTITION      512

--- a/target/z3s/include/target/board_info.h
+++ b/target/z3s/include/target/board_info.h
@@ -18,6 +18,8 @@
 #define CONFIG_SUB_PMIC_S2DOS05
 #define CONFIG_UFS_BOARD_TYPE	1      /* smdk : 0, universal : 1 */
 
+#define CONFIG_SKIP_MMC_INIT
+
 #define CONFIG_USE_RPMB
 #define CONFIG_USE_F2FS
 #define RPMB_BLOCK_PER_PARTITION      512


### PR DESCRIPTION
It's useless and can cause issues when booting with an SD card inserted, it also causes slower boot times when an SD card is inserted.