### PR TITLE
Project: Fix regression in booting android cause of uninitialised mainline quirks value

### DIFF
--- a/platform/exynos9830/platform.c
+++ b/platform/exynos9830/platform.c
@@ -47,6 +47,8 @@
 #include <ctype.h>
 #include <platform/b_rev.h>
 
+#include <lk3rd/mainline_quirks.h>
+
 #ifdef CONFIG_GET_B_REV_FROM_ADC
 #include <dev/exynos_adc.h>
 #include <target/b_rev_adc.h>
@@ -414,6 +416,7 @@ void platform_init(void)
 {
 	u32 ret = 0;
 	u32 rst_stat = readl(POWER_RST_STAT);
+	int mainline_quirks_enabled;
 
 	display_flexpmu_dbg();
 	print_acpm_version();
@@ -532,4 +535,9 @@ by_dumpgpr_out:
 	display_dvfs_info();
 
 	chg_init_max77705();
+
+	mainline_quirks_enabled = lk3rd_get_mainline_quirks();
+
+	if(mainline_quirks_enabled != 0 && mainline_quirks_enabled != 1) // Not a sane value, most likely uninitialised, so we initialise it.
+		lk3rd_switch_mainline_quirks(false);
 }


### PR DESCRIPTION
Without this, getting the status of mainline quirks on a fresh lk3rd install returns an invalid value, making the device try to boot android with mainline quirks enabled, although it being displayed as disabled in the menu resulting in the device never booting android.