### PR TITLE
Project: persistent_storage: Fix critical issue in persistent storage offset handling

### DIFF
--- a/lib/fastboot/fastboot_cmd.c
+++ b/lib/fastboot/fastboot_cmd.c
@@ -40,6 +40,7 @@
 #include <dev/rpmb.h>
 #include <dev/scsi.h>
 #include <dev/pmucal_local.h>
+#include <lk3rd/persistent_storage.h>
 #include <lk3rd/mainline_quirks.h>
 #include <lk3rd/fastboot_menu.h>
 
@@ -704,6 +705,14 @@ int fb_do_flash(char *cmd_buffer, unsigned int rx_sz)
 	{
 		print_lcd_update(FONT_ORANGE, FONT_BLACK, "Patching lk3rd, please do not turn off/reboot your device.");
 
+		int persistent_storage_entry_num = sizeof(enum persistent_storage_entries);
+		int persistent_entries[persistent_storage_entry_num] = {};
+
+		for(int i = 0; i < persistent_storage_entry_num; i++)
+		{
+			persistent_entries[i] = persistent_storage_read(i);
+		}
+
 		void *part = part_get("lk3rd");
 		struct pit_entry *lk3rd_entry = (struct pit_entry *)part;
 
@@ -722,6 +731,13 @@ int fb_do_flash(char *cmd_buffer, unsigned int rx_sz)
 
 		flash_using_part("lk3rd", response, lk3rd_entry->blknum * PIT_UFS_BLK_SIZE, (void *)BOOT_BASE);
 
+		print_lcd_update(FONT_ORANGE, FONT_BLACK, "Restoring settings...");
+
+		for(int i = 0; i < persistent_storage_entry_num; i++)
+		{
+			persistent_storage_write(i, persistent_entries[i]);
+		}
+
 		print_lcd_update(FONT_GREEN, FONT_BLACK, "Patch complete!");
 
 		void *part_boot = part_get("boot");
@@ -734,7 +750,15 @@ int fb_do_flash(char *cmd_buffer, unsigned int rx_sz)
 	}
 	else if(!strcmp(dest, "lk3rd"))
 	{
-		print_lcd_update(FONT_ORANGE, FONT_BLACK, "Patching LK3RD, please do not turn off/reboot your device.");
+		print_lcd_update(FONT_ORANGE, FONT_BLACK, "Patching lk3rd, please do not turn off/reboot your device.");
+
+		int persistent_storage_entry_num = sizeof(enum persistent_storage_entries);
+		int persistent_entries[persistent_storage_entry_num] = {};
+
+		for(int i = 0; i < persistent_storage_entry_num; i++)
+		{
+			persistent_entries[i] = persistent_storage_read(i);
+		}
 
 		void *part = part_get("lk3rd");
 
@@ -761,6 +785,13 @@ int fb_do_flash(char *cmd_buffer, unsigned int rx_sz)
 
 		flash_using_part("lk3rd", response,
 			downloaded_data_size, (void *)interface.transfer_buffer);
+
+		print_lcd_update(FONT_ORANGE, FONT_BLACK, "Restoring settings...");
+
+		for(int i = 0; i < persistent_storage_entry_num; i++)
+		{
+			persistent_storage_write(i, persistent_entries[i]);
+		}
 
 		print_lcd_update(FONT_GREEN, FONT_BLACK, "Patch complete!");
 

--- a/lib/lk3rd/persistent_storage.c
+++ b/lib/lk3rd/persistent_storage.c
@@ -10,8 +10,7 @@
 #include <part.h>
 #include <lk3rd/persistent_storage.h>
 
-#define PERSISTENT_STORAGE_OFFSET 0x175000
-#define PERSISTENT_STORAGE_SIZE 0x2000
+#define PERSISTENT_STORAGE_OFFSET (0x175000)
 #define PERSISTENT_STORAGE_ENTRIES sizeof(persistent_storage_entries)
 #define TEMP_BUFFER_OFFSET 0x94000000
 
@@ -22,11 +21,9 @@ int persistent_storage_read(int entry)
 
 	part = part_get("lk3rd");
 
-	part_read_partial(part, (void*)TEMP_BUFFER_OFFSET,
-				PERSISTENT_STORAGE_OFFSET,
-				PERSISTENT_STORAGE_SIZE);
+	part_read(part, (void*)TEMP_BUFFER_OFFSET);
 
-	return buffer[entry];
+	return buffer[(PERSISTENT_STORAGE_OFFSET / sizeof(int)) + entry];
 }
 
 int persistent_storage_write(int entry, int value)
@@ -36,15 +33,11 @@ int persistent_storage_write(int entry, int value)
 
 	part = part_get("lk3rd");
 
-	part_read_partial(part, (void*)TEMP_BUFFER_OFFSET,
-				PERSISTENT_STORAGE_OFFSET,
-				PERSISTENT_STORAGE_SIZE);
+	part_read(part, (void*)TEMP_BUFFER_OFFSET);
 
-	buffer[entry] = value;
+	buffer[(PERSISTENT_STORAGE_OFFSET / sizeof(int)) + entry] = value;
 
-	part_write_partial(part, (void*)TEMP_BUFFER_OFFSET,
-				 PERSISTENT_STORAGE_OFFSET,
-				 PERSISTENT_STORAGE_SIZE);
+	part_write(part, (void*)TEMP_BUFFER_OFFSET);
 
 	printf("Wrote %i to %x\n", value, *buffer);
 


### PR DESCRIPTION
This commit fixes incorrect handling of persistent storage,
where UFS sectors aren't accounted for, this means we are most
likely writing to some other partition, like boot, this
will cause instabilities in userspace if not handled.

While fixing persistent storage's handling, this had
introduced a new bug, where reflashing lk3rd didn't
preserve settings, with some modifications to the
patching procedure to preserve the settings, I can
say the persistent storage is now fully safe to use.
