### PR TITLE
build: Bail out on error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 
 boards=("maestro9610" "universal9630" "maestro9820" "smdk9830" "universal9830_bringup" "phoenix9830" "c1s" "c2s" "r8s" "x1s" "y2s" "z3s" "erd3830" "universal3830")
 


### PR DESCRIPTION
Fixes "no such file or directory" errors as well as GH Actions "succeeding" even if the compilation failed.