### PR TITLE
power: pmic: s2mps_19_22: Correct shutdown command

### DIFF
--- a/dev/power/pmic/s2mps_19_22/pmic_s2mps_19_22.c
+++ b/dev/power/pmic/s2mps_19_22/pmic_s2mps_19_22.c
@@ -213,7 +213,11 @@ void pmic_disable_smpl(void) {
 }
 
 void pmic_shutdown(void) {
-	unsigned char reg = 0x80;
+	unsigned char reg;
+
+	speedy_read(CONFIG_SPEEDY1_BASE, S2MPS22_PM_ADDR, S2MPS22_PM_CTRL1, &reg);
+
+	reg |= (1 << 7);
 
 	speedy_write(CONFIG_SPEEDY1_BASE, S2MPS22_PM_ADDR, S2MPS22_PM_CTRL1, reg);
 }


### PR DESCRIPTION
0x80 seemed to be non-harmful but lets fix it anyways for the sake of using proper stuff.