### PR TITLE
Fix framebuffer being garbled on certain boots and some code cleanup

### DIFF
--- a/lib/font/exynos_font.c
+++ b/lib/font/exynos_font.c
@@ -27,6 +27,9 @@
 
 #include "exynos_font.h"
 #include <dpu/lcd_ctrl.h>
+
+#include <platform/mmu/cache.h>
+
 #include <target/dpu_config.h>
 
 #define PRINT_BUF_SIZE			384
@@ -98,6 +101,8 @@ void draw_squircle(uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint
 			}
 		}
 	}
+
+	clean_invalidate_dcache_all();
 }
 
 void draw_line(uint32_t x1, uint32_t y1, uint32_t x2, uint32_t y2, uint32_t width, uint32_t color)
@@ -159,6 +164,8 @@ void draw_triangle(uint32_t x1, uint32_t y1, uint32_t x2, uint32_t y2, uint32_t 
 			}
 		}
 	}
+
+	clean_invalidate_dcache_all();
 }
 
 /* Clears the framebuffer by filling it with a specified color */
@@ -166,12 +173,16 @@ void clear_screen(uint32_t color)
 {
 	y_pos = 0;
 	draw_rectangle(0, 0, LCD_WIDTH, LCD_HEIGHT, color);
+
+	clean_invalidate_dcache_all();
 }
 
 void clear_line(uint32_t color, uint32_t clear_y_pos, bool reset_y_pos)
 {
 	if (reset_y_pos) y_pos = 0;
 	draw_rectangle(0, clear_y_pos, LCD_WIDTH, FONT_Y, color);
+
+	clean_invalidate_dcache_all();
 }
 
 /* Fill the frame buffer one character at a time */
@@ -240,6 +251,7 @@ static int fill_fb_one_char(u32 *fb_buf, u32 x_pos, u32 fb_width, char ascii,
 static void initialize_font_fb(void)
 {
 	memset((void *)CONFIG_DISPLAY_FONT_BASE_ADDRESS, 0, LCD_WIDTH * LCD_HEIGHT * 4);
+	clean_invalidate_dcache_all();
 }
 
 /* Fill one line of the frame buffer with characters */
@@ -301,6 +313,8 @@ int fill_fb_string(u32 *fb_buf, u32 x_pos, u8 *str, u32 font_color, u32 bg_color
 			str = str + MAX_NUM_CHAR_PER_LINE;
 		}
 	} while (lgth > 0);
+
+	clean_invalidate_dcache_all();
 
 	return 0;
 }

--- a/lib/font/exynos_font.c
+++ b/lib/font/exynos_font.c
@@ -29,15 +29,8 @@
 #include <dpu/lcd_ctrl.h>
 #include <target/dpu_config.h>
 
-/*
-#include <target/lcd_module.h>
-*/
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-static u32 y_pos = 0;
-
+#define PRINT_BUF_SIZE			384
+#define TOP_MARGIN			40
 #define MAX_NUM_CHAR_PER_LINE		(LCD_WIDTH / (FONT_X + 1))
 #define ALPHANUMERIC_OFFSET		0
 #define LENGTH_OF_A_CHAR_ARRAY		((FONT_Y) * 2)
@@ -45,6 +38,10 @@ static u32 y_pos = 0;
 #ifndef LCD_OFFSET 
 #define LCD_OFFSET			0
 #endif
+
+static u32 y_pos = 0;
+u32 _win_fb0 = 0xf1000000;
+extern void decon_string_update(void);
 
 void draw_pixel(uint32_t x, uint32_t y, uint32_t color)
 {
@@ -77,23 +74,30 @@ void draw_squircle(uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint
 		}
 	}
 
-    for (uint32_t i = 0; i <= radius; i++)
-    {
-        for (uint32_t j = 0; j <= radius; j++)
-        {
-            if (i * i + j * j <= radius * radius)
-            {
-                // Top-left corner
-				if (corners[0]) draw_pixel(x + radius - i, y + radius - j, color);
+	for (uint32_t i = 0; i <= radius; i++)
+	{
+		for (uint32_t j = 0; j <= radius; j++)
+		{
+			if (i * i + j * j <= radius * radius)
+			{
+				// Top-left corner
+				if (corners[0])
+					draw_pixel(x + radius - i, y + radius - j, color);
+
 				// Top-right corner
-				if (corners[1]) draw_pixel(x + width - radius + i - 1, y + radius - j, color);
+				if (corners[1])
+					draw_pixel(x + width - radius + i - 1, y + radius - j, color);
+
 				// Bottom-left corner
-				if (corners[2]) draw_pixel(x + radius - i, y + height - radius + j - 1, color);
+				if (corners[2])
+					draw_pixel(x + radius - i, y + height - radius + j - 1, color);
+
 				// Bottom-right corner
-				if (corners[3]) draw_pixel(x + width - radius + i - 1, y + height - radius + j - 1, color);
-            }
-        }
-    }
+				if (corners[3])
+					draw_pixel(x + width - radius + i - 1, y + height - radius + j - 1, color);
+			}
+		}
+	}
 }
 
 void draw_line(uint32_t x1, uint32_t y1, uint32_t x2, uint32_t y2, uint32_t width, uint32_t color)
@@ -174,40 +178,52 @@ void clear_line(uint32_t color, uint32_t clear_y_pos, bool reset_y_pos)
 static int fill_fb_one_char(u32 *fb_buf, u32 x_pos, u32 fb_width, char ascii,
 	u32 y_pos, u32 font_color, u32 bg_color)
 {
-int i, j;
-u32 offset; /* Offset of font array, exynos_font.h */
-u32 *fb_ptr;
+	int i, j;
+	u32 offset; /* Offset of font array, exynos_font.h */
+	u32 *fb_ptr;
 
-/* From Null(0x00) to '~'(0x7E) */
-if (ascii < 32 || ascii > 126)
-	return -1;
+	/* From Null(0x00) to '~'(0x7E) */
+	if (ascii < 32 || ascii > 126)
+		return -1;
 
-offset = LENGTH_OF_A_CHAR_ARRAY * (ascii - ALPHANUMERIC_OFFSET);
+	offset = LENGTH_OF_A_CHAR_ARRAY * (ascii - ALPHANUMERIC_OFFSET);
 
-	for (i = 0; i < FONT_Y; i++) {
+	for (i = 0; i < FONT_Y; i++)
+	{
 		/* Move to fill next or start pixel of fb */
 		fb_ptr = fb_buf + ((i + y_pos) * fb_width) + x_pos;
 
 		/* Fill a first half part of a font width, 8bit */
-		for (j = 0; j < (FONT_X / 2); j++) {
-			if (font[offset] & (1 << j)) {
+		for (j = 0; j < (FONT_X / 2); j++)
+		{
+			if (font[offset] & (1 << j))
+			{
 				/* Filled area in font */
 				fb_ptr[(FONT_X / 2 - 1) - j] = font_color;
-			} else {
+			}
+			else
+			{
 				/* Unfilled area in font */
 				fb_ptr[(FONT_X / 2 - 1) - j] = bg_color;
 			}
 		}
+
 		/* Move to next (FONT / 2) pixel pointer of fb */
 		fb_ptr = fb_ptr + (FONT_X / 2);
+
 		/* Move to next (FONT / 2) pixel pointer of font */
 		offset++;
+
 		/* Fill the other half part of a font width, 8bit */
-		for (j = 0; j < (FONT_X / 2); j++) {
-			if (font[offset] & (1 << j)) {
+		for (j = 0; j < (FONT_X / 2); j++)
+		{
+			if (font[offset] & (1 << j))
+			{
 				/* Filled area in font */
 				fb_ptr[(FONT_X / 2 - 1) - j] = font_color;
-			} else {
+			}
+			else
+			{
 				/* Unfilled area in font */
 				fb_ptr[(FONT_X / 2 - 1) - j] = bg_color;
 			}
@@ -217,7 +233,7 @@ offset = LENGTH_OF_A_CHAR_ARRAY * (ascii - ALPHANUMERIC_OFFSET);
 		offset++;
 	}
 
-return 0;
+	return 0;
 }
 
 
@@ -240,14 +256,16 @@ static int _fill_fb_string(u32 *fb_buf, u32 x_pos, u8 *str,
 	else
 		cnt = lgth;
 
-	if (y_pos > LCD_HEIGHT - LCD_OFFSET) {
+	if (y_pos > LCD_HEIGHT - LCD_OFFSET)
+	{
 		/* Rolling fb, y_pos and fb address reinit */
 		y_pos = 0;
 		fb_buf = (u32 *)CONFIG_DISPLAY_FONT_BASE_ADDRESS;
 		initialize_font_fb();
 	}
 
-	for (i = 0; i < cnt; i++) {
+	for (i = 0; i < cnt; i++)
+	{
 		ch = *(str++);
 		if (fill_fb_one_char(fb_buf, x_pos + (i * FONT_X), LCD_WIDTH,
 			ch, y_pos + LCD_OFFSET, font_color, bg_color)) {
@@ -271,10 +289,12 @@ int fill_fb_string(u32 *fb_buf, u32 x_pos, u8 *str, u32 font_color, u32 bg_color
 	else
 		lgth = strlen((char *)str);
 
-	do {
+	do
+	{
 		lgth = _fill_fb_string(fb_buf, x_pos, str,
 					font_color, bg_color, lgth);
-		if (lgth) {
+		if (lgth)
+		{
 			/* for updating the position of the remaining
 			 * string points after filling one line of the LCD.
 			 */
@@ -284,11 +304,6 @@ int fill_fb_string(u32 *fb_buf, u32 x_pos, u8 *str, u32 font_color, u32 bg_color
 
 	return 0;
 }
-
-#define PRINT_BUF_SIZE 384
-#define TOP_MARGIN	40
-u32 _win_fb0 = 0xf1000000;
-extern void decon_string_update(void);
 
 int print_lcd(u32 font_color, u32 bg_color, const char *fmt, ...)
 {
@@ -304,7 +319,8 @@ int print_lcd(u32 font_color, u32 bg_color, const char *fmt, ...)
 	va_end(args);
 
 	if (fill_fb_string((u32 *)ptr, TOP_MARGIN,
-				(u8 *)printbuffer, font_color, bg_color)) {
+				(u8 *)printbuffer, font_color, bg_color))
+	{
 		printf("failed to print on lcd\n");
 		return -1;
 	}
@@ -326,7 +342,8 @@ int print_lcd_update(u32 font_color, u32 bg_color, const char *fmt, ...)
 	va_end(args);
 
 	if (fill_fb_string((u32 *)ptr, TOP_MARGIN,
-				(u8 *)printbuffer, font_color, bg_color)) {
+				(u8 *)printbuffer, font_color, bg_color))
+	{
 		printf("failed to print on lcd\n");
 		return -1;
 	}

--- a/platform/exynos9830/debug.c
+++ b/platform/exynos9830/debug.c
@@ -14,80 +14,80 @@
 #include <platform/uart.h>
 #include <types.h>
 #include <stdint.h>
+#include <kernel/thread.h>
+#include "exynos_font.h"
 
 #define FB_BASE ((u32 *)0xf1000000)
 
 volatile u32 *fb = FB_BASE;
-
-/* Clears the framebuffer by filling it with a specified color */
-void clear_screen(uint32_t color);
-
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
-
-#include <stdint.h>
-#include <kernel/thread.h>
-#include "exynos_font.h"
 
 // Global cursor position and color.
 static u32 cursor_x = 0;
 static u32 cursor_y = 0;
 static u32 text_color = 0xFFFFFF; // Default white color.
 
+/* Clears the framebuffer by filling it with a specified color */
+void clear_screen(uint32_t color);
+
 // Helper function to draw a character.
 void putc_fb(char c)
 {
-    // Address of framebuffer (assuming RGB format and 32-bit pixels).
-    volatile u32 *fb = FB_BASE;
+	// Address of framebuffer (assuming RGB format and 32-bit pixels).
+	volatile u32 *fb = FB_BASE;
 
-    // Handle newline.
-    if (c == '\n')
-    {
-	cursor_x = 0;
-	cursor_y += FONT_Y;
-	if (cursor_y + 3*FONT_Y > LCD_HEIGHT)
+	// Handle newline.
+	if (c == '\n')
 	{
-	    clear_screen(0); // Clear the screen.
-	    cursor_y = 0; // Reset to the top if we overflow.
-	}
-	return;
-    }
+		cursor_x = 0;
+		cursor_y += FONT_Y;
 
-    const u8 *char_data = &font[(c - ' ') * FONT_Y * 2];
-
-    // Iterate through each pixel of the character.
-    for (u32 row = 0; row < FONT_Y; ++row)
-    {
-	// Each row in the font is 2 bytes (16 bits).
-	u16 row_data = (char_data[row * 2] << 8) | char_data[row * 2 + 1];
-
-	for (u32 col = 0; col < FONT_X; ++col)
-	{
-	    // Check if the bit at position `col` is set.
-	    if (row_data & (1 << (15 - col)))
-	    {
-		// Draw the pixel at the corresponding framebuffer location.
-		u32 pixel_x = cursor_x + col;
-		u32 pixel_y = cursor_y + row;
-		if (pixel_x < LCD_WIDTH && pixel_y < LCD_HEIGHT)
+		if (cursor_y + 3*FONT_Y > LCD_HEIGHT)
 		{
-		    fb[pixel_y * LCD_WIDTH + pixel_x] = text_color;
+			clear_screen(0); // Clear the screen.
+			cursor_y = 0; // Reset to the top if we overflow.
 		}
-	    }
+		return;
 	}
-    }
-    // Move cursor to the next character position.
-    cursor_x += FONT_X;
-    if (cursor_x + FONT_X > LCD_WIDTH)
-    { // Handle line wrap.
-	cursor_x = 0;
-	cursor_y += FONT_Y;
 
-	if (cursor_y + FONT_Y > LCD_HEIGHT)
+	const u8 *char_data = &font[(c - ' ') * FONT_Y * 2];
+
+	// Iterate through each pixel of the character.
+	for (u32 row = 0; row < FONT_Y; ++row)
 	{
-	    cursor_y = 0; // Reset to the top if we overflow.
+		// Each row in the font is 2 bytes (16 bits).
+		u16 row_data = (char_data[row * 2] << 8) | char_data[row * 2 + 1];
+
+		for (u32 col = 0; col < FONT_X; ++col)
+		{
+			// Check if the bit at position `col` is set.
+			if (row_data & (1 << (15 - col)))
+			{
+				// Draw the pixel at the corresponding framebuffer location.
+				u32 pixel_x = cursor_x + col;
+				u32 pixel_y = cursor_y + row;
+
+				if (pixel_x < LCD_WIDTH && pixel_y < LCD_HEIGHT)
+				{
+					fb[pixel_y * LCD_WIDTH + pixel_x] = text_color;
+				}
+			}
+		}
 	}
-    }
+
+	// Move cursor to the next character position.
+	cursor_x += FONT_X;
+
+	if (cursor_x + FONT_X > LCD_WIDTH)
+	{
+		// Handle line wrap.
+		cursor_x = 0;
+		cursor_y += FONT_Y;
+
+		if (cursor_y + FONT_Y > LCD_HEIGHT)
+		{
+			cursor_y = 0; // Reset to the top if we overflow.
+		}
+	}
 }
 
 void uart_char_out(char cData);

--- a/platform/exynos9830/debug.c
+++ b/platform/exynos9830/debug.c
@@ -12,6 +12,7 @@
  */
 #include <platform/debug.h>
 #include <platform/uart.h>
+#include <platform/mmu/cache.h>
 #include <types.h>
 #include <stdint.h>
 #include <kernel/thread.h>
@@ -88,6 +89,8 @@ void putc_fb(char c)
 			cursor_y = 0; // Reset to the top if we overflow.
 		}
 	}
+
+	clean_invalidate_dcache_all();
 }
 
 void uart_char_out(char cData);


### PR DESCRIPTION
# FAQ

## Why not do this on every pixel write
Its slow.

## Why not just clean the framebuffer range in cache
Its slow.

## Disable the D-Cache
It makes EVERYTHING slow.