### PR TITLE
exynos_boot: boot: cmd_boot: Don't disable KASLR anymore and handle it properly

### DIFF
--- a/app/exynos_boot/boot/cmd_boot.c
+++ b/app/exynos_boot/boot/cmd_boot.c
@@ -579,6 +579,36 @@ mem_node_out:
 
 int cmd_scatter_load_boot(int argc, const cmd_args *argv);
 
+void kaslr_warning(void)
+{
+	int warning_x = LCD_WIDTH / 20;
+	int warning_y = 103;
+	int warning_width = LCD_WIDTH * 3 / 32;
+	int warning_height = LCD_HEIGHT * .0375;
+	int warning_thickness = LCD_WIDTH / 80;
+
+	draw_rectangle(0, 0, LCD_WIDTH, 800, FONT_BLACK);
+
+	draw_rectangle(0, 5, LCD_WIDTH, (warning_height + 75) + 150, FONT_RED);
+
+	draw_triangle(warning_x + warning_width / 2, warning_y, warning_x, warning_y + warning_height, warning_x + warning_width, warning_y + warning_height, FONT_WHITE); // triangle
+	draw_full_squircle(warning_x + warning_width / 2 - warning_thickness / 2, warning_y + warning_height / 3, warning_thickness,  warning_height / 3, warning_thickness / 2, FONT_RED); // |
+	draw_circle(warning_x + warning_width / 2 - warning_thickness / 2, warning_y + warning_height * 27 / 36, warning_thickness / 2, FONT_RED); //                                          .
+
+	update_y_pos(5 + FONT_Y);
+
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "Warning!"));
+	print_lcd_update(FONT_WHITE, FONT_RED, "");
+
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "This device currently has KASLR disabled, this means you're"));
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "currently running an insecure environment, this should not be used"));
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "for daily usage, your device may currently be more prone to exploits"));
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "If this was not intentional, please immediately reboot your phone to"));
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "fastboot and run"));
+	print_lcd_update(FONT_WHITE, FONT_RED, "");
+	print_lcd_update(FONT_WHITE, FONT_RED, empty_pad_string((warning_x + warning_width + 18) / FONT_X, "fastboot oem enable-kaslr"));
+}
+
 int load_boot_images(void)
 {
 	struct pit_entry *ptn;
@@ -689,18 +719,24 @@ int cmd_boot(int argc, const cmd_args *argv)
 	if (readl(EXYNOS9830_POWER_SYSIP_DAT0) == REBOOT_MODE_RECOVERY ||
 	    readl(EXYNOS9830_POWER_SYSIP_DAT0) == REBOOT_MODE_FACTORY)
 		writel(0, EXYNOS9830_POWER_SYSIP_DAT0);
+
 	/* notify EL3 Monitor end of bootloader */
 	exynos_smc(SMC_CMD_END_OF_BOOTLOADER, 0, 0, 0);
 
 	//print_lcd_update(FONT_GREEN, FONT_BLACK, "About to jump to kernel! Good night!");
 
-	thread_sleep(100); // Give DECON ample time to render before shutdown.
+	if(kaslr_status == 0)
+	{
+		kaslr_warning();
+		thread_sleep(100); // Give DECON ample time to render before shutdown.
+	}
 
 	printf("DECON0: HW_SW_TRIG Restore\n");
 	writel(0x3070, 0x19050070);
 
 	/* before jumping to kernel. disble arch_timer */
 	arm_generic_timer_disable();
+
 	/* before jumping to kernel. disable interrupt */
 	arch_disable_ints();
 
@@ -844,7 +880,11 @@ int boot_fb_boot(unsigned long buf_addr, size_t size)
 
 	//print_lcd_update(FONT_GREEN, FONT_BLACK, "About to jump to kernel! Good night!");
 
-	thread_sleep(100); // Give DECON ample time to render before shutdown.
+	if(kaslr_status == 0)
+	{
+		kaslr_warning();
+		thread_sleep(100); // Give DECON ample time to render before shutdown.
+	}
 
 	printf("DECON0: HW_SW_TRIG Restore\n");
 	writel(0x3070, 0x19050070);

--- a/app/exynos_boot/boot/cmd_boot.c
+++ b/app/exynos_boot/boot/cmd_boot.c
@@ -44,6 +44,7 @@
 #include <kernel/thread.h>
 
 #include <lk3rd/boot_reason.h>
+#include <lk3rd/kaslr_status.h>
 #include <lk3rd/mainline_quirks.h>
 
 #include <app/exynos_boot/cmd_boot.h>
@@ -74,6 +75,8 @@ struct bootargs_prop {
 };
 static struct bootargs_prop prop[32] = { { { 0, }, { 0, } }, };
 static int prop_cnt = 0;
+
+static u32 kaslr_offset;
 
 extern volatile char *bootloader_cmdline;
 
@@ -580,6 +583,8 @@ int load_boot_images(void)
 {
 	struct pit_entry *ptn;
 	cmd_args argv[6];
+	int kaslr_status = lk3rd_get_kaslr_status();
+	kaslr_offset = readl(0x80001004);
 
 	if (readl(EXYNOS9830_POWER_SYSIP_DAT0) == REBOOT_MODE_RECOVERY || readl(EXYNOS9830_POWER_SYSIP_DAT0) == REBOOT_MODE_FACTORY) {
 		ptn = pit_get_part_info("recovery");
@@ -626,7 +631,10 @@ int load_boot_images(void)
 	}
 
 	argv[1].u = BOOT_BASE;
-	argv[2].u = KERNEL_BASE;
+	if(kaslr_status == 1)
+		argv[2].u = KERNEL_BASE + kaslr_offset;
+	else
+		argv[2].u = KERNEL_BASE;
 #if defined(CONFIG_RAMDISK_IN_BOOT)
 	argv[3].u = RAMDISK_BASE;
 #else
@@ -645,6 +653,8 @@ int load_boot_images(void)
 
 int cmd_boot(int argc, const cmd_args *argv)
 {
+	int kaslr_status = lk3rd_get_kaslr_status();
+
 	fdt_dtb = (struct fdt_header *)DT_BASE;
 	dtbo_table = (struct dt_table_header *)DTBO_BASE;
 
@@ -697,13 +707,20 @@ int cmd_boot(int argc, const cmd_args *argv)
 	clean_invalidate_dcache_all();
 	disable_mmu_dcache();
 
-	/* GTFO KASLR - you're making VaultKeeper sad :( */
-	writel(0, 0x80001000 + sizeof(u32));
+	if(kaslr_status == 0)
+	{
+		// Turn off KASLR
+		writel(0, 0x80001004);
+	}
 
 	printf("Starting kernel...\n");
 	void (*kernel_entry)(int r0, int r1, int r2, int r3);
 
-	kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE;
+	if(kaslr_status == 1)
+		kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE + kaslr_offset;
+	else
+		kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE;
+
 	kernel_entry(DT_BASE, 0, 0, 0);
 
 	return 0;
@@ -738,6 +755,8 @@ int boot_fb_boot(unsigned long buf_addr, size_t size)
 	struct pit_entry *ptn;
 	cmd_args argv[7];
 	struct boot_img_hdr *b_hdr;
+	int kaslr_status = lk3rd_get_kaslr_status();
+	kaslr_offset = readl(0x80001004);
 
 	memset((void *)BOOT_BASE, 0, SZ_64M);
 	memcpy((void *)BOOT_BASE, (void *)buf_addr, size);
@@ -776,7 +795,11 @@ int boot_fb_boot(unsigned long buf_addr, size_t size)
 	memset((void *)RAMDISK_BASE, 0, 0x200000);
 
 	argv[1].u = BOOT_BASE;
-	argv[2].u = KERNEL_BASE;
+	if(kaslr_status == 1)
+		argv[2].u = KERNEL_BASE + kaslr_offset;
+	else
+		argv[2].u = KERNEL_BASE;
+
 	argv[3].u = RAMDISK_BASE;
 	argv[4].u = DT_BASE;
 	argv[5].u = 0x0;
@@ -835,13 +858,20 @@ int boot_fb_boot(unsigned long buf_addr, size_t size)
 	clean_invalidate_dcache_all();
 	disable_mmu_dcache();
 
-	/* GTFO KASLR - you're making VaultKeeper sad :( */
-	writel(0, 0x80001000 + sizeof(u32));
+	if(kaslr_status == 0)
+	{
+		// Turn off KASLR
+		writel(0, 0x80001004);
+	}
 
 	printf("Starting kernel...\n");
 	void (*kernel_entry)(int r0, int r1, int r2, int r3);
 
-	kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE;
+	if(kaslr_status == 1)
+		kernel_entry = (void (*)(int, int, int, int))KERNEL_BASE + kaslr_offset;
+	else
+		kernel_entry = (void(*)(int, int, int, int))KERNEL_BASE;
+
 	kernel_entry(DT_BASE, 0, 0, 0);
 
 	return 0;

--- a/include/lib/font_display.h
+++ b/include/lib/font_display.h
@@ -58,4 +58,6 @@ void clear_line(uint32_t color, uint32_t line_number, bool reset_y_pos);
 u32 get_y_pos(void);
 void update_y_pos(u32 y);
 
+const char *empty_pad_string(u32 pad, const char *str);
+
 #endif /* __FONT_DISPLAY_H__ */

--- a/lib/fastboot/fastboot_cmd.c
+++ b/lib/fastboot/fastboot_cmd.c
@@ -41,6 +41,7 @@
 #include <dev/scsi.h>
 #include <dev/pmucal_local.h>
 #include <lk3rd/persistent_storage.h>
+#include <lk3rd/kaslr_status.h>
 #include <lk3rd/mainline_quirks.h>
 #include <lk3rd/fastboot_menu.h>
 
@@ -242,6 +243,8 @@ const char *oem_commands[] =
 	"reboot-download",
 	"enable-mainline-quirks",
 	"disable-mainline-quirks",
+	"enable-kaslr",
+	"disable-kaslr",
 };
 
 enum oem_commands_id
@@ -250,6 +253,8 @@ enum oem_commands_id
 	OEM_REBOOT_DOWNLOAD,
 	OEM_ENABLE_MAINLINE_QUIRKS,
 	OEM_DISABLE_MAINLINE_QUIRKS,
+	OEM_ENABLE_KASLR,
+	OEM_DISABLE_KASLR,
 	OEM_CMD_END,
 };
 
@@ -1049,6 +1054,26 @@ int fb_do_oem(char *cmd_buffer, unsigned int rx_sz)
 					sprintf(response, "OKAY");
 				notify_action_switch(0);
 				break;
+
+		case OEM_ENABLE_KASLR:
+			ret = lk3rd_switch_kaslr_status(1);
+			if(ret != 1)
+				sprintf(response, "FAIL");
+			else
+				sprintf(response, "OKAY");
+
+			notify_action_switch(0);
+			break;
+
+                case OEM_DISABLE_KASLR:
+			ret = lk3rd_switch_kaslr_status(0);
+			if(ret != 0)
+				sprintf(response, "FAIL");
+			else
+				sprintf(response, "OKAY");
+
+			notify_action_switch(0);
+			break;
 
 		default:
 			sprintf(response, "FAILunsupported command");

--- a/lib/font/exynos_font.c
+++ b/lib/font/exynos_font.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdio.h> /* TODO : divide print_lcd function */
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include "exynos_font.h"
 #include <dpu/lcd_ctrl.h>
@@ -375,4 +376,16 @@ u32 get_y_pos(void)
 void update_y_pos(u32 y)
 {
 	y_pos = y;
+}
+
+const char *empty_pad_string(u32 pad, const char *str)
+{
+	u32 str_length = strlen(str);
+	char *padded_string = malloc(pad + str_length + 1);
+
+	memset(padded_string, '\200', pad);
+	memcpy(padded_string + pad, str, str_length);
+	padded_string[pad + str_length] = '\0';
+
+	return padded_string;
 }

--- a/lib/lk3rd/display.c
+++ b/lib/lk3rd/display.c
@@ -46,18 +46,6 @@ const char* add_padding(uint16_t left, uint16_t right, const char *str)
 	return padded_str;
 }
 
-const char *empty_pad_string(u32 pad, const char *str)
-{
-	u32 str_length = strlen(str);
-	char *padded_string = malloc(pad + str_length + 1);
-
-	memset(padded_string, '\200', pad);
-	memcpy(padded_string + pad, str, str_length);
-	padded_string[pad + str_length] = '\0';
-
-	return padded_string;
-}
-
 const char *title_case(const char *str) {
 	char *title_str = malloc(strlen(str) + 1);
 	int newWord = 1;

--- a/lib/lk3rd/display.c
+++ b/lib/lk3rd/display.c
@@ -20,6 +20,7 @@
 #include "include/lk3rd/display.h"
 #include "include/lk3rd/fastboot_menu.h"
 #include "include/lk3rd/mainline_quirks.h"
+#include "include/lk3rd/kaslr_status.h"
 #include "../lib/font/exynos_font.h"
 
 void draw_line_lcd(int color_fg, int color_bg)
@@ -204,6 +205,15 @@ void draw_menu(enum action current_action)
 		print_lcd_update(FONT_YELLOW, FONT_BLACK, empty_pad_string(strlen("Mainline quirks: "), "enabled ")); 
 	else
 		print_lcd_update(FONT_GREEN, FONT_BLACK, empty_pad_string(strlen("Mainline quirks: "), "disabled"));
+
+	orig_y_pos = get_y_pos();
+	print_lcd_update(FONT_WHITE, FONT_BLACK, "KASLR status: ");
+	update_y_pos(orig_y_pos);
+
+	if(lk3rd_get_kaslr_status() == 1)
+		print_lcd_update(FONT_GREEN, FONT_BLACK, empty_pad_string(strlen("KASLR status: "), "enabled "));
+	else
+		print_lcd_update(FONT_RED, FONT_BLACK, empty_pad_string(strlen("KASLR status: "), "disabled"));
 
 	orig_y_pos = get_y_pos();
 	print_lcd_update(FONT_WHITE, FONT_BLACK, "Enter reason: ");

--- a/lib/lk3rd/include/lk3rd/display.h
+++ b/lib/lk3rd/include/lk3rd/display.h
@@ -15,6 +15,7 @@
 #include "fastboot_menu.h"
 
 #define FONT_X 16
+#define FONT_Y 32
 #define MAX_NUM_CHAR_PER_LINE ((LCD_WIDTH / FONT_X) - 6)
 
 void draw_menu(enum action current_action);

--- a/lib/lk3rd/include/lk3rd/kaslr_status.h
+++ b/lib/lk3rd/include/lk3rd/kaslr_status.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Umer Uddin <umer.uddin@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+#pragma once
+
+int lk3rd_switch_kaslr_status(bool enable);
+int lk3rd_get_kaslr_status(void);

--- a/lib/lk3rd/include/lk3rd/persistent_storage.h
+++ b/lib/lk3rd/include/lk3rd/persistent_storage.h
@@ -15,6 +15,7 @@ int persistent_storage_write(int entry, int value);
 
 enum persistent_storage_entries {
         LK3RD_MAINLINE_QUIRKS = 0x0,
+	LK3RD_KASLR_STATUS    = 0x1,
 };
 
 #endif // LK3RD_PERSISTENTSTORAGE_H

--- a/lib/lk3rd/kaslr_status.c
+++ b/lib/lk3rd/kaslr_status.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Umer Uddin <umer.uddin@mentallysanemainliners.org>
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ *
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <lk3rd/persistent_storage.h>
+#include <lk3rd/mainline_quirks.h>
+
+int lk3rd_switch_kaslr_status(bool enable)
+{
+	int ret;
+
+	persistent_storage_write(LK3RD_KASLR_STATUS, enable);
+
+	ret = persistent_storage_read(LK3RD_KASLR_STATUS);
+
+	if(ret != enable)
+	{
+		printf("lk3rd: couldn't write to persistent storage, e: %i g: %i\n",
+		       enable, ret);
+	}
+
+	return ret;
+}
+
+int lk3rd_get_kaslr_status(void)
+{
+	return persistent_storage_read(LK3RD_KASLR_STATUS);
+}

--- a/lib/lk3rd/rules.mk
+++ b/lib/lk3rd/rules.mk
@@ -5,6 +5,7 @@ MODULE := $(LOCAL_DIR)
 MODULE_SRCS += \
 	$(LOCAL_DIR)/display.c \
 	$(LOCAL_DIR)/fastboot_menu.c \
+	$(LOCAL_DIR)/kaslr_status.c \
 	$(LOCAL_DIR)/keys.c \
 	$(LOCAL_DIR)/mainline_quirks.c \
 	$(LOCAL_DIR)/persistent_storage.c \

--- a/make/build.mk
+++ b/make/build.mk
@@ -14,10 +14,17 @@ endif
 
 $(EXTRA_LINKER_SCRIPTS):
 
-$(ANDROID_BOOT_IMAGE) : $(OUTBIN_LK3RD)
+$(ANDROID_BOOT_IMAGE): $(OUTBIN_LK3RD)
 	@echo lk3rd: creating an android boot image for $(PROJECT)
-	mkbootimg --kernel $(OUTBIN_LK3RD) --ramdisk ./Resources/dummyramdisk $(MKBOOTIMG_ARGS) -o $@
-	@echo lk3rd: all done! image can be found at $@
+	mkbootimg --kernel $(OUTBIN_LK3RD) --ramdisk ./Resources/dummyramdisk $(MKBOOTIMG_ARGS) -o $@.tmp
+	@echo lk3rd: Padding image...
+	@pad_size=$$((2097152 - $$(stat -c "%s" $@.tmp))) && \
+		fallocate -l $$pad_size $@.pad
+	cat $@.tmp $@.pad > $@
+	rm $@.tmp $@.pad
+	@echo lk3rd: Writing default KASLR and Mainline Quirks settings...
+	printf '\x00\x00\x00\x00\x01\x00\x00\x00' | dd of=$@ bs=1 seek=$$((0x175000)) conv=notrunc
+	@echo lk3rd: all done! Image is at $@
 
 $(OUTBIN_LK3RD) : $(OUTBIN)
 	@echo lk3rd: building final image base: $(MEMBASE): $@

--- a/platform/exynos9830/platform.c
+++ b/platform/exynos9830/platform.c
@@ -49,6 +49,7 @@
 #include <platform/b_rev.h>
 
 #include <lk3rd/boot_reason.h>
+#include <lk3rd/kaslr_status.h>
 #include <lk3rd/mainline_quirks.h>
 
 #ifdef CONFIG_GET_B_REV_FROM_ADC
@@ -451,11 +452,24 @@ static void print_acpm_version(void)
 #endif /* ifdef EXYNOS_ACPM_BASE */
 }
 
+void sanitise_persistent_storage(void)
+{
+	int option_enabled;
+
+        option_enabled = lk3rd_get_mainline_quirks();
+	if(option_enabled != 0 && option_enabled != 1) // Not a sane value
+		lk3rd_switch_mainline_quirks(false);
+
+	option_enabled = lk3rd_get_kaslr_status();
+	if(option_enabled != 0 && option_enabled != 1) // Not a sane value  
+		lk3rd_switch_kaslr_status(true);
+
+}
+
 void platform_init(void)
 {
 	u32 ret = 0;
 	u32 rst_stat = readl(POWER_RST_STAT);
-	int mainline_quirks_enabled;
 
 	display_flexpmu_dbg();
 	print_acpm_version();
@@ -577,8 +591,5 @@ by_dumpgpr_out:
 
 	chg_init_max77705();
 
-	mainline_quirks_enabled = lk3rd_get_mainline_quirks();
-
-	if(mainline_quirks_enabled != 0 && mainline_quirks_enabled != 1) // Not a sane value, most likely uninitialised, so we initialise it.
-		lk3rd_switch_mainline_quirks(false);
+	sanitise_persistent_storage();
 }


### PR DESCRIPTION
Technically adds security back, though honestly theres not exactly much benefit for us here, we run on unlocked bootloaders anyway, this is more of a nice to have than anything.